### PR TITLE
synching 'AvailableTraded' type with current API response

### DIFF
--- a/objects/company_valuation.go
+++ b/objects/company_valuation.go
@@ -340,6 +340,7 @@ type AvailableTraded struct {
 	Price             float64 `json:"price"`
 	Exchange          string  `json:"exchange"`
 	ExchangeShortName string  `json:"exchangeShortName"`
+	Type              string  `json:"type"`
 }
 
 // IPOCalendar ...


### PR DESCRIPTION
I noticed the "Type" field is missing from the "AvailableTraded" type. Please accept this update.

Thanks.