### PR TITLE
add date parameter to EODBatchPrices and fix EODBatchPrices unmarshal

### DIFF
--- a/stock.go
+++ b/stock.go
@@ -574,13 +574,13 @@ func (s *Stock) PriceChangeBatch(symbolList []string) (sList []objects.StockPric
 }
 
 // EODBatchPrices ...
-func (s *Stock) EODBatchPrices() (sList []objects.StockEODCandle, err error) {
-	data, err := s.Client.Get(urlAPIStockEODBatchPrices, nil)
+func (s *Stock) EODBatchPrices(date time.Time) (sList []objects.StockEODCandle, err error) {
+	data, err := s.Client.Get(urlAPIStockEODBatchPrices, map[string]string{"date": date.Format("2006-01-02")})
 	if err != nil {
 		return nil, err
 	}
 
-	err = jsoniter.Unmarshal(data.Body(), &sList)
+	err = gocsv.UnmarshalBytes(data.Body(), &sList)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The v4 batch price endpoint takes a date parameter. This change lets us pass in a date.

Additionally, the v4 batch price endpoint returns data in CSV format. This unmarshals using the correct format.